### PR TITLE
⬆️ Bump Google GA provider lock to 3.19.0, remove google-beta provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v6.1.0] - 2020-05-04
+### Changed
+- Upgrade Google GA provider lock to `~> 3.19.0`, remove `google-beta` provider as all needed versions are now in GA.
+
 ## [v6.0.0] - 2020-04-07
 ### Added
 - Add automatic documentation

--- a/README.md
+++ b/README.md
@@ -41,14 +41,13 @@ pre-commit install
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12 |
-| google | ~> 2.20.0 |
-| google-beta | ~> 3.6 |
+| google | ~> 3.19.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| google | ~> 2.20.0 |
+| google | ~> 3.19.0 |
 | kubernetes | n/a |
 | tls | n/a |
 

--- a/main.tf
+++ b/main.tf
@@ -173,7 +173,7 @@ resource "tls_private_key" "provision" {
 }
 
 resource "google_compute_firewall" "elasticsearch_allow_cluster" {
-  name     = "elasticserach-allow-cluster-${var.instance_name}"
+  name     = "elasticsearch-allow-cluster-${var.instance_name}"
   network  = "default"
   priority = "1000"
 

--- a/providers.tf
+++ b/providers.tf
@@ -1,7 +1,3 @@
 provider "google" {
-  version = "~> 2.20.0"
-}
-
-provider "google-beta" {
-  version = "~> 3.6"
+  version = "~> 3.19.0"
 }


### PR DESCRIPTION
Related: #43227