### PR TITLE
🚑 Fix master_list local variable - add suffix to master list. 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.26.0
+  rev: v1.45.0
   hooks:
     - id: terraform_fmt
     - id: terraform_docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v8.4.1] - 2021-01-07
+### Fixed
+- Local variable `master_list` did not included random name suffix, which resulted in non-existing hostnames for bootstrap
+
 ## [v8.4.0] - 2020-10-02
 ### Added
 - Add Fluentd configuration for Elasticsearch cluster log file
@@ -30,9 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed internal load-balancer from internal-managed to TCP internal
 ### Removed
 - Public IP addresses from the cluster nodes
-### Add
+### Added
 - Add provisioning of compute instances from ssh provisioners to user-data metadata
-### Fix
+### Fixed
 - Elasticsearch's `network.host` configuration directive to enable TCP internal load-balancer traffic and health checks
 
 ## [v7.0.0] - 2020-06-23

--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,7 @@ locals {
   master_list = join(",",
     [
       for i in range(var.node_count) :
-      "${var.instance_name}-${i}"
+      "${var.instance_name}-${i}${local.suffix}"
     ]
   )
   suffix = var.add_random_suffix ? "-${random_string.es_name_suffix[0].result}" : ""


### PR DESCRIPTION
Provisioning have non-existing hostnames without it